### PR TITLE
Suporte a CNPJ alfanumérico (validação, formatação e testes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require brunoconte3/dev-utils
 Or add to your `composer.json`:
 
 ```json
-"brunoconte3/dev-utils": "2.8.0"
+"brunoconte3/dev-utils": "2.9.0"
 ```
 
 ## Data Validation Example
@@ -209,7 +209,7 @@ require 'vendor/autoload.php';
 
 use DevUtils\Format;
 
-Format::companyIdentification('39678379000129'); //CNPJ ==> 39.678.379/0001-29
+Format::companyIdentification('A1B2C3D45E6F59'); //CNPJ ==> A1.B2C.3D4/5E6F-59
 Format::convertTimestampBrazilToAmerican('15/04/2021 19:50:25'); //Convert Timestamp Brazil to American format
 Format::currency('113', 'R$ '); //Default currency BR ==> 123.00 - the 2nd parameter chooses the Currency label
 Format::currencyUsd('1123.45'); //Default currency USD ==> 1,123.45 - the 2nd parameter chooses the Currency label
@@ -434,10 +434,10 @@ Compare::compareStringFrom('sistema', 'sistema/teste', 0, 7);
 require 'vendor/autoload.php';
 
 use DevUtils\ValidateCnpj;
-ValidateCnpj::validateCnpj('57.169.078/0001-51'); //Returns boolean, example true [Can pass with mask]
+ValidateCnpj::validateCnpj('A1.B2C.3D4/5E6F-59'); //Returns boolean, example true [Can pass without mask]
 
 use DevUtils\validateCpf;
-ValidateCpf::validateCpf('257.877.760-89'); //Returns boolean, example true [Can pass with mask]
+ValidateCpf::validateCpf('257.877.760-89'); //Returns boolean, example true [Can pass without mask]
 
 use DevUtils\ValidateDate;
 //Examples return true

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,11 @@
             "name": "Erick Hiroki Abe / 阿部広紀",
             "email": "erickhirokiabe@gmail.com",
             "role": "Developer"
+        },
+        {
+            "name": "Thales Santos",
+            "email": "thales_sblue@hotmail.com",
+            "role": "Developer"
         }
     ],
     "support": {

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.1",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -65,20 +65,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T12:36:36+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
                 "shasum": ""
             },
             "require": {
@@ -97,7 +97,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -121,9 +121,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-10-21T19:32:17+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -245,16 +245,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.17",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
-            },
+            "version": "2.1.31",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
-                "reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
                 "shasum": ""
             },
             "require": {
@@ -299,38 +294,38 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-21T20:55:28+00:00"
+            "time": "2025-10-10T14:14:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.3.0",
+            "version": "12.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "9075a8efc66e11bc55c319062e147bdb06777267"
+                "reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9075a8efc66e11bc55c319062e147bdb06777267",
-                "reference": "9075a8efc66e11bc55c319062e147bdb06777267",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
+                "reference": "67e8aed88f93d0e6e1cb7effe1a2dfc2fee6022c",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.4.0",
+                "nikic/php-parser": "^5.6.1",
                 "php": ">=8.3",
                 "phpunit/php-file-iterator": "^6.0",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
-                "sebastian/environment": "^8.0",
+                "sebastian/environment": "^8.0.3",
                 "sebastian/lines-of-code": "^4.0",
                 "sebastian/version": "^6.0",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.1"
+                "phpunit/phpunit": "^12.3.7"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -339,7 +334,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.3.x-dev"
+                    "dev-main": "12.4.x-dev"
                 }
             },
             "autoload": {
@@ -368,7 +363,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.3.0"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.4.0"
             },
             "funding": [
                 {
@@ -388,7 +383,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-23T15:49:03+00:00"
+            "time": "2025-09-24T13:44:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -637,16 +632,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.1.6",
+            "version": "12.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2fdf0056c673c8f0f1eed00030be5f8243c1e6e0"
+                "reference": "fc5413a2e6d240d2f6d9317bdf7f0a24e73de194"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2fdf0056c673c8f0f1eed00030be5f8243c1e6e0",
-                "reference": "2fdf0056c673c8f0f1eed00030be5f8243c1e6e0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fc5413a2e6d240d2f6d9317bdf7f0a24e73de194",
+                "reference": "fc5413a2e6d240d2f6d9317bdf7f0a24e73de194",
                 "shasum": ""
             },
             "require": {
@@ -656,23 +651,23 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.1",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.2.1",
+                "phpunit/php-code-coverage": "^12.4.0",
                 "phpunit/php-file-iterator": "^6.0.0",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
-                "sebastian/cli-parser": "^4.0.0",
-                "sebastian/comparator": "^7.0.1",
+                "sebastian/cli-parser": "^4.2.0",
+                "sebastian/comparator": "^7.1.3",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.1",
-                "sebastian/exporter": "^7.0.0",
-                "sebastian/global-state": "^8.0.0",
+                "sebastian/environment": "^8.0.3",
+                "sebastian/exporter": "^7.0.2",
+                "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
-                "sebastian/type": "^6.0.2",
+                "sebastian/type": "^6.0.3",
                 "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
             },
@@ -682,7 +677,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "12.1-dev"
+                    "dev-main": "12.4-dev"
                 }
             },
             "autoload": {
@@ -714,7 +709,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.1.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.1"
             },
             "funding": [
                 {
@@ -738,20 +733,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T12:36:31+00:00"
+            "time": "2025-10-09T14:08:29+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "4.0.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "6d584c727d9114bcdc14c86711cd1cad51778e7c"
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/6d584c727d9114bcdc14c86711cd1cad51778e7c",
-                "reference": "6d584c727d9114bcdc14c86711cd1cad51778e7c",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/90f41072d220e5c40df6e8635f5dafba2d9d4d04",
+                "reference": "90f41072d220e5c40df6e8635f5dafba2d9d4d04",
                 "shasum": ""
             },
             "require": {
@@ -763,7 +758,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -787,28 +782,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:53:50+00:00"
+            "time": "2025-09-14T09:36:45+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.0.1",
+            "version": "7.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "b478f34614f934e0291598d0c08cbaba9644bee5"
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b478f34614f934e0291598d0c08cbaba9644bee5",
-                "reference": "b478f34614f934e0291598d0c08cbaba9644bee5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
                 "shasum": ""
             },
             "require": {
@@ -819,7 +826,7 @@
                 "sebastian/exporter": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^12.0"
+                "phpunit/phpunit": "^12.2"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -827,7 +834,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -867,15 +874,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-03-07T07:00:32+00:00"
+            "time": "2025-08-20T11:27:00+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1004,16 +1023,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.2",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "d364b9e5d0d3b18a2573351a1786fbf96b7e0792"
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d364b9e5d0d3b18a2573351a1786fbf96b7e0792",
-                "reference": "d364b9e5d0d3b18a2573351a1786fbf96b7e0792",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
                 "shasum": ""
             },
             "require": {
@@ -1056,7 +1075,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
             },
             "funding": [
                 {
@@ -1076,20 +1095,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T15:05:44+00:00"
+            "time": "2025-08-12T14:11:56+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "7.0.0",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "76432aafc58d50691a00d86d0632f1217a47b688"
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/76432aafc58d50691a00d86d0632f1217a47b688",
-                "reference": "76432aafc58d50691a00d86d0632f1217a47b688",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/016951ae10980765e4e7aee491eb288c64e505b7",
+                "reference": "016951ae10980765e4e7aee491eb288c64e505b7",
                 "shasum": ""
             },
             "require": {
@@ -1146,28 +1165,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:56:42+00:00"
+            "time": "2025-09-24T06:16:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "8.0.0",
+            "version": "8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "570a2aeb26d40f057af686d63c4e99b075fb6cbc"
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/570a2aeb26d40f057af686d63c4e99b075fb6cbc",
-                "reference": "570a2aeb26d40f057af686d63c4e99b075fb6cbc",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ef1377171613d09edd25b7816f05be8313f9115d",
+                "reference": "ef1377171613d09edd25b7816f05be8313f9115d",
                 "shasum": ""
             },
             "require": {
@@ -1208,15 +1239,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.0"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.2"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:56:59+00:00"
+            "time": "2025-08-29T11:29:25+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1392,16 +1435,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "c405ae3a63e01b32eb71577f8ec1604e39858a7c"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/c405ae3a63e01b32eb71577f8ec1604e39858a7c",
-                "reference": "c405ae3a63e01b32eb71577f8ec1604e39858a7c",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
@@ -1444,28 +1487,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T05:00:01+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "6.0.2",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "1d7cd6e514384c36d7a390347f57c385d4be6069"
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/1d7cd6e514384c36d7a390347f57c385d4be6069",
-                "reference": "1d7cd6e514384c36d7a390347f57c385d4be6069",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e549163b9760b8f71f191651d22acf32d56d6d4d",
+                "reference": "e549163b9760b8f71f191651d22acf32d56d6d4d",
                 "shasum": ""
             },
             "require": {
@@ -1501,15 +1556,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-03-18T13:37:31+00:00"
+            "time": "2025-08-09T06:57:12+00:00"
         },
         {
             "name": "sebastian/version",

--- a/public_html/Index.php
+++ b/public_html/Index.php
@@ -37,17 +37,21 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPAR
                 <div>
                     <?php
                     echo '<p>Aqui vem os seus testes!</p>';
+
+                    $validator = new Validator();
+
+                    $cnpj = Format::companyIdentification('A1B2C3D45E6F59');
+                    echo '<br> Teste dados válidos identifierOrCompany => ' . $cnpj;
                     $array = [
-                        'cpfOuCnpj' => '04764334879',
-                        'nomePais' => 'Brasil',
-                        'dadosEmpresa' => ['empresa' => 'cooper'],
+                        'cpfOuCnpj' => $cnpj,
+                        'nomeCidade' => 'Maringá',
+                        'dadosEmpresa' => ['empresa' => 'CooperTec'],
                     ];
                     $rules = [
                         'cpfOuCnpj' => 'identifierOrCompany',
-                        'nomePais' => 'required|alpha',
+                        'nomeCidade' => 'required|alpha',
                         'dadosEmpresa' => 'required|array',
                     ];
-                    $validator = new Validator();
                     $validator->set($array, $rules);
                     ?>
                     <pre>

--- a/public_html/Index.php
+++ b/public_html/Index.php
@@ -40,10 +40,10 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPAR
 
                     $validator = new Validator();
 
-                    $cnpj = Format::companyIdentification('A1B2C3D45E6F59');
-                    echo '<br> Teste dados válidos identifierOrCompany => ' . $cnpj;
+                    $cpfOuCnpj = Format::identifierOrCompany('DEVUTILS123404');
+                    echo '<br> Teste dados válidos identifierOrCompany => ' . $cpfOuCnpj;
                     $array = [
-                        'cpfOuCnpj' => $cnpj,
+                        'cpfOuCnpj' => $cpfOuCnpj,
                         'nomeCidade' => 'Maringá',
                         'dadosEmpresa' => ['empresa' => 'CooperTec'],
                     ];

--- a/src/Arrays.php
+++ b/src/Arrays.php
@@ -8,9 +8,10 @@ use DevUtils\Format;
 
 class Arrays
 {
-    public static function searchKey(array $array, string $key): mixed
+    public static function searchKey(array $array, string $key): ?int
     {
-        return Format::falseToNull(array_search(key([$key => null]), array_keys($array), true));
+        $result = array_search(key([$key => null]), array_keys($array), true);
+        return $result === false ? null : $result;
     }
 
     public static function renameKey(array &$array, string $oldKey, string $newKey): bool

--- a/src/DependencyInjection/Rules.php
+++ b/src/DependencyInjection/Rules.php
@@ -216,7 +216,7 @@ class Rules
     }
 
     protected function validateRuleField(
-        mixed $field,
+        string|int $field,
         mixed $value,
         mixed $rules,
         bool $valid = false,

--- a/src/DependencyInjection/TraitRuleString.php
+++ b/src/DependencyInjection/TraitRuleString.php
@@ -65,10 +65,7 @@ trait TraitRuleString
         ?string $value = '',
         ?string $message = '',
     ): void {
-        if (is_numeric($value) && strlen($value) === 14) {
-            $value = Format::mask('##.###.###/####-##', $value);
-        }
-        if (empty($value) || !ValidateCnpj::validateCnpj($value, $rule)) {
+        if (empty($value)  || !ValidateCnpj::validateCnpj($value, $rule)) {
             $this->errors[$field] = !empty($message) ?
                 $message : "O campo $field é inválido!";
         }
@@ -155,7 +152,7 @@ trait TraitRuleString
         if (strlen($value) === 11) {
             $value = Format::mask('###.###.###-##', $value);
         }
-        if (is_numeric($value) && strlen($value) === 14) {
+        if (strlen($value) === 14 && ctype_digit(substr($value, 12, 2))) {
             $value = Format::mask('##.###.###/####-##', $value);
         }
         if (strlen($value) === 14 && !ValidateCpf::validateCpf($value)) {

--- a/src/Format.php
+++ b/src/Format.php
@@ -76,9 +76,22 @@ class Format extends FormatAux
 
     public static function companyIdentification(string $cnpj): string
     {
-        parent::validateForFormatting('companyIdentification', 14, $cnpj);
-        $retorno = preg_replace("/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/", "\$1.\$2.\$3/\$4-\$5", $cnpj);
-        return $retorno ?? '';
+        $companyIdentification = strtoupper(strval(preg_replace('/[^A-Z0-9]/', '', $cnpj)));
+
+        if (!preg_match('/^[A-Z0-9]{12}\d{2}$/', $companyIdentification)) {
+            throw new InvalidArgumentException(
+                'companyIdentification precisa conter 12 caracteres alfanuméricos seguidos de 2 dígitos!'
+            );
+        }
+
+        return sprintf(
+            '%s.%s.%s/%s-%s',
+            substr($companyIdentification, 0, 2),
+            substr($companyIdentification, 2, 3),
+            substr($companyIdentification, 5, 3),
+            substr($companyIdentification, 8, 4),
+            substr($companyIdentification, 12, 2)
+        );
     }
 
     public static function identifier(string $cpf): string

--- a/src/ValidateCnpj.php
+++ b/src/ValidateCnpj.php
@@ -55,17 +55,23 @@ class ValidateCnpj
 
         for ($i = 0, $j = 5, $sum = 0; $i < 12; $i++) {
             $v = self::cnpjCharValue($cnpj[$i]);
-            if ($v < 0) return false;
+            if ($v < 0) {
+                return false;
+            }
             $sum += $v * $j;
             $j = ($j == 2) ? 9 : $j - 1;
         }
         $rest = $sum % 11;
         $dv1  = ($rest < 2) ? 0 : 11 - $rest;
-        if ((int)$cnpj[12] !== $dv1) return false;
+        if ((int)$cnpj[12] !== $dv1) {
+            return false;
+        }
 
         for ($i = 0, $j = 6, $sum = 0; $i < 13; $i++) {
             $v = ($i < 12) ? self::cnpjCharValue($cnpj[$i]) : $dv1;
-            if ($v < 0) return false;
+            if ($v < 0) {
+                return false;
+            }
             $sum += $v * $j;
             $j = ($j == 2) ? 9 : $j - 1;
         }
@@ -83,8 +89,12 @@ class ValidateCnpj
     private static function cnpjCharValue(string $ch): int
     {
         $o = ord($ch);
-        if ($o >= 48 && $o <= 57) return $o - 48;
-        if ($o >= 65 && $o <= 90) return $o - 48;
+        if ($o >= 48 && $o <= 57) {
+            return $o - 48;
+        }
+        if ($o >= 65 && $o <= 90) {
+            return $o - 48;
+        }
         return -1;
     }
 

--- a/src/ValidateCnpj.php
+++ b/src/ValidateCnpj.php
@@ -8,16 +8,29 @@ class ValidateCnpj
         string $cnpj,
         string | array | bool $cnpjException = '',
     ): bool {
+        if (!ctype_digit($cnpj)) {
+            return true;
+        }
         $cnpjInvalidate = [
-            '00000000000000', '11111111111111', '22222222222222', '33333333333333', '44444444444444',
-            '55555555555555', '66666666666666', '77777777777777', '88888888888888', '99999999999999',
+            '00000000000000',
+            '11111111111111',
+            '22222222222222',
+            '33333333333333',
+            '44444444444444',
+            '55555555555555',
+            '66666666666666',
+            '77777777777777',
+            '88888888888888',
+            '99999999999999',
         ];
 
-        if ((empty($cnpjException) || is_bool($cnpjException)) && in_array($cnpj, $cnpjInvalidate)) {
+        if ((empty($cnpjException) || is_bool($cnpjException)) && in_array($cnpj, $cnpjInvalidate, true)) {
             return false;
         }
         if (
-            is_string($cnpjException) && in_array($cnpj, $cnpjInvalidate) && in_array($cnpjException, $cnpjInvalidate)
+            is_string($cnpjException) &&
+            in_array($cnpj, $cnpjInvalidate, true) &&
+            in_array($cnpjException, $cnpjInvalidate, true)
         ) {
             return true;
         }
@@ -25,45 +38,54 @@ class ValidateCnpj
             $cnpjExceptionValid = [];
             foreach ($cnpjException as $key => $nrInscricao) {
                 $cnpjExceptionValid[$key] = false;
-                if (in_array($nrInscricao, $cnpjInvalidate) && in_array($cnpj, $cnpjInvalidate)) {
+                if (in_array($nrInscricao, $cnpjInvalidate, true) && in_array($cnpj, $cnpjInvalidate, true)) {
                     $cnpjExceptionValid[$key] = true;
                 }
             }
-            return (in_array(false, $cnpjExceptionValid)) ? false : true;
+            return (in_array(false, $cnpjExceptionValid, true)) ? false : true;
         }
         return true;
     }
 
     private static function validateRuleCnpj(string $cnpj): bool
     {
-        if (strlen($cnpj) > 14) {
-            $cnpj = self::dealCnpj($cnpj);
-        }
-        if (strlen($cnpj) < 14) {
+        if (strlen($cnpj) !== 14 || !ctype_digit(substr($cnpj, 12, 2))) {
             return false;
         }
 
         for ($i = 0, $j = 5, $sum = 0; $i < 12; $i++) {
-            $sum += intval($cnpj[$i]) * $j;
+            $v = self::cnpjCharValue($cnpj[$i]);
+            if ($v < 0) return false;
+            $sum += $v * $j;
             $j = ($j == 2) ? 9 : $j - 1;
         }
         $rest = $sum % 11;
-        if ($cnpj[12] != ($rest < 2 ? 0 : 11 - $rest)) {
-            return false;
-        }
+        $dv1  = ($rest < 2) ? 0 : 11 - $rest;
+        if ((int)$cnpj[12] !== $dv1) return false;
+
         for ($i = 0, $j = 6, $sum = 0; $i < 13; $i++) {
-            $sum += intval($cnpj[$i]) * $j;
+            $v = ($i < 12) ? self::cnpjCharValue($cnpj[$i]) : $dv1;
+            if ($v < 0) return false;
+            $sum += $v * $j;
             $j = ($j == 2) ? 9 : $j - 1;
         }
         $rest = $sum % 11;
-        return $cnpj[13] == ($rest < 2 ? 0 : 11 - $rest);
+        $dv2  = ($rest < 2) ? 0 : 11 - $rest;
+
+        return (int)$cnpj[13] === $dv2;
     }
 
     private static function dealCnpj(string $cnpj): string
     {
-        $newCnpj = preg_match('/[0-9]/', $cnpj) ?
-            str_replace(['-', '.', '/'], '', str_pad($cnpj, 14, '0', STR_PAD_LEFT), $cnpj) : 0;
-        return strval($newCnpj);
+        return strtoupper(strval(preg_replace('/[^A-Z0-9]/i', '', $cnpj)));
+    }
+
+    private static function cnpjCharValue(string $ch): int
+    {
+        $o = ord($ch);
+        if ($o >= 48 && $o <= 57) return $o - 48;
+        if ($o >= 65 && $o <= 90) return $o - 48;
+        return -1;
     }
 
     public static function validateCnpj(string $cnpj, string | array | bool $cnpjException = ''): bool
@@ -71,9 +93,7 @@ class ValidateCnpj
         if (empty($cnpj)) {
             return false;
         }
-        if (strlen($cnpj) > 14) {
-            $cnpj = self::dealCnpj($cnpj);
-        }
+        $cnpj = self::dealCnpj($cnpj);
         if (!self::validateCnpjSequenceInvalidate($cnpj, $cnpjException)) {
             return false;
         }

--- a/tests/UnitFormatTest.php
+++ b/tests/UnitFormatTest.php
@@ -18,6 +18,7 @@ class UnitFormatTest extends TestCase
     public function testCompanyIdentification(): void
     {
         self::assertEquals('76.027.484/0001-24', Format::companyIdentification('76027484000124'));
+        self::assertEquals('BR.ASI.L20/26AA-64', Format::companyIdentification('BRASIL2026AA64'));
     }
 
     public function testConvertTypes(): void
@@ -83,6 +84,7 @@ class UnitFormatTest extends TestCase
     {
         self::assertEquals('307.208.700-89', Format::identifierOrCompany('30720870089'));
         self::assertEquals('12.456.571/0001-14', Format::identifierOrCompany('12456571000114'));
+        self::assertEquals('A1.B2C.3D4/5E6F-59', Format::identifierOrCompany('A1B2C3D45E6F59'));
     }
 
     public function testTelephone(): void

--- a/tests/UnitRuleTest.php
+++ b/tests/UnitRuleTest.php
@@ -481,8 +481,8 @@ class UnitRuleTest extends TestCase
     public function testIdentifierOrCompany(): void
     {
         $array = [
-            'cpfOuCnpjerror' => '96.284.092.0001/59',
-            'cpfOuCnpjValid' => '96.284.092/0001-58',
+            'cpfOuCnpjerror' => '9E.2A4.092.0001/5A',
+            'cpfOuCnpjValid' => 'DE.VUT.ILS/123X-49',
             'cpfOuCnpjExceptionError' => '12.123.456/0007-12',
             'cpfOuCnpjExceptionValid' => '00.000.000/0000-00',
             'cpfOuCnpjInvalid' => '0966894790',

--- a/tests/UnitUtilityTest.php
+++ b/tests/UnitUtilityTest.php
@@ -23,7 +23,7 @@ class UnitUtilityTest extends TestCase
         self::assertTrue(boolval(preg_match('@[A-Z]@', $passWordFull)));
         self::assertTrue(boolval(preg_match('@[a-z]@', $passWordFull)));
         self::assertTrue(boolval(preg_match('@[0-9]@', $passWordFull)));
-        self::assertTrue(boolval(preg_match("/(?=.*[^A-Za-zd])/", $passWordFull)));
+        self::assertTrue(boolval(preg_match("/(?=.*[^A-Za-z\\d])/", $passWordFull)));
     }
 
     public function testBuildUrl(): void

--- a/tests/UnitValidateCnpjTest.php
+++ b/tests/UnitValidateCnpjTest.php
@@ -7,11 +7,170 @@ namespace DevUtils\Test;
 use DevUtils\ValidateCnpj;
 use PHPUnit\Framework\TestCase;
 
-class UnitValidateCnpjTest extends TestCase
+final class UnitValidateCnpjTest extends TestCase
 {
-    public function testValidate(): void
+    private static function charValue(string $ch): int
     {
-        self::assertEquals(true, ValidateCnpj::validateCnpj('57.169.078/0001-51'));
-        self::assertEquals(false, ValidateCnpj::validateCnpj('55.569.078/0001-51'));
+        $n = ord($ch);
+        if ($n >= 48 && $n <= 57) return $n - 48;
+        if ($n >= 65 && $n <= 90) return $n - 48;
+        return -1;
+    }
+
+    private static function calcDv(string $root): array
+    {
+        $w1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+        $sum = 0;
+        for ($i = 0; $i < 12; $i++) $sum += self::charValue($root[$i]) * $w1[$i];
+        $r1 = $sum % 11;
+        $dv1 = ($r1 < 2) ? 0 : 11 - $r1;
+
+        $w2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+        $sum = 0;
+        for ($i = 0; $i < 13; $i++) {
+            $v = $i < 12 ? self::charValue($root[$i]) : $dv1;
+            $sum += $v * $w2[$i];
+        }
+        $r2 = $sum % 11;
+        $dv2 = ($r2 < 2) ? 0 : 11 - $r2;
+
+        return [$dv1, $dv2];
+    }
+
+    private static function makeRawCnpj(string $root): string
+    {
+        [$dv1, $dv2] = self::calcDv($root);
+        return strtoupper($root) . $dv1 . $dv2;
+    }
+
+    private static function maskCnpj(string $raw): string
+    {
+        return sprintf(
+            '%s.%s.%s/%s-%s',
+            substr($raw, 0, 2),
+            substr($raw, 2, 3),
+            substr($raw, 5, 3),
+            substr($raw, 8, 4),
+            substr($raw, 12, 2)
+        );
+    }
+
+    public function testValidNumericExamples(): void
+    {
+        self::assertTrue(ValidateCnpj::validateCnpj('57.169.078/0001-51'));
+        self::assertFalse(ValidateCnpj::validateCnpj('55.569.078/0001-51'));
+        self::assertTrue(ValidateCnpj::validateCnpj('11.222.333/0001-81'));
+        self::assertFalse(ValidateCnpj::validateCnpj('11.222.333/0001-82'));
+        self::assertTrue(ValidateCnpj::validateCnpj('11222333000181'));
+        self::assertFalse(ValidateCnpj::validateCnpj('11222333000182'));
+    }
+
+    public function testRejectEmptyAndWhitespace(): void
+    {
+        self::assertFalse(ValidateCnpj::validateCnpj(''));
+        self::assertFalse(ValidateCnpj::validateCnpj('   '));
+    }
+
+    public function testValidAlphanumericMaskedAndRaw(): void
+    {
+        $roots = ['ABCDEFGHIJKL', 'A1B2C3D45E6F', 'XYZ123456ABC', 'AAAABBBBCCCC'];
+
+        foreach ($roots as $root) {
+            $raw = self::makeRawCnpj($root);
+            $masked = self::maskCnpj($raw);
+            self::assertTrue(ValidateCnpj::validateCnpj($raw));
+            self::assertTrue(ValidateCnpj::validateCnpj($masked));
+        }
+    }
+
+    public function testAcceptLowercase(): void
+    {
+        $root = 'abcDefGhijKl';
+        $rawUpper = self::makeRawCnpj(strtoupper($root));
+        $rawLower = strtolower($rawUpper);
+        $maskedLower = strtolower(self::maskCnpj($rawUpper));
+
+        self::assertTrue(ValidateCnpj::validateCnpj($rawLower));
+        self::assertTrue(ValidateCnpj::validateCnpj($maskedLower));
+    }
+
+    public function testRejectAlphanumericWithWrongDv(): void
+    {
+        $root = 'XYZ123456ABC';
+        $raw = self::makeRawCnpj($root);
+        $tampered = substr($raw, 0, 13) . ((int)$raw[13] ^ 1);
+        self::assertFalse(ValidateCnpj::validateCnpj($tampered));
+    }
+
+    public function testRejectLettersInDv(): void
+    {
+        $root = 'A1B2C3D45E6F';
+        [$dv1, $dv2] = self::calcDv($root);
+        $withLetterAtDv1 = $root . 'A' . $dv2;
+        $withLetterAtDv2 = $root . $dv1 . 'B';
+
+        self::assertFalse(ValidateCnpj::validateCnpj($withLetterAtDv1));
+        self::assertFalse(ValidateCnpj::validateCnpj($withLetterAtDv2));
+    }
+
+    public function testSanitizeNoiseAndKeepAlnum(): void
+    {
+        $root = 'ABCDEFGHIJKL';
+        $raw = self::makeRawCnpj($root);
+        $masked = self::maskCnpj($raw);
+
+        $noisyRaw = preg_replace('/(.)/', '$1!@', $raw);
+        $noisyMasked = preg_replace('/(.)/', '#$1 ', $masked);
+
+        self::assertTrue(ValidateCnpj::validateCnpj($noisyRaw));
+        self::assertTrue(ValidateCnpj::validateCnpj($noisyMasked));
+    }
+
+    public function testRejectWrongLengthAfterSanitize(): void
+    {
+        self::assertFalse(ValidateCnpj::validateCnpj('AB.CDE'));
+        self::assertFalse(ValidateCnpj::validateCnpj('123456789012345'));
+    }
+
+    public function testRejectNumericSequences(): void
+    {
+        self::assertFalse(ValidateCnpj::validateCnpj('00.000.000/0000-00'));
+        self::assertFalse(ValidateCnpj::validateCnpj('11.111.111/1111-11'));
+        self::assertFalse(ValidateCnpj::validateCnpj('22.222.222/2222-22'));
+        self::assertFalse(ValidateCnpj::validateCnpj('33.333.333/3333-33'));
+        self::assertFalse(ValidateCnpj::validateCnpj('44.444.444/4444-44'));
+        self::assertFalse(ValidateCnpj::validateCnpj('55.555.555/5555-55'));
+        self::assertFalse(ValidateCnpj::validateCnpj('66.666.666/6666-66'));
+        self::assertFalse(ValidateCnpj::validateCnpj('77.777.777/7777-77'));
+        self::assertFalse(ValidateCnpj::validateCnpj('88.888.888/8888-88'));
+        self::assertFalse(ValidateCnpj::validateCnpj('99.999.999/9999-99'));
+    }
+
+    public function testWhitelistStillRequiresValidDv(): void
+    {
+        $raw00 = self::makeRawCnpj(str_repeat('0', 12));
+        self::assertTrue(ValidateCnpj::validateCnpj(self::maskCnpj($raw00), '00000000000000'));
+
+        self::assertFalse(ValidateCnpj::validateCnpj('11.111.111/1111-11', ['11111111111111']));
+        self::assertFalse(ValidateCnpj::validateCnpj('22.222.222/2222-22', ['22222222222222']));
+
+        $raw11 = self::makeRawCnpj(str_repeat('1', 12));
+        self::assertTrue(ValidateCnpj::validateCnpj(self::maskCnpj($raw11)));
+
+        $raw22 = self::makeRawCnpj(str_repeat('2', 12));
+        self::assertTrue(ValidateCnpj::validateCnpj(self::maskCnpj($raw22)));
+    }
+
+    public function testBooleanExceptionDoesNotWhitelist(): void
+    {
+        self::assertFalse(ValidateCnpj::validateCnpj('00.000.000/0000-00', true));
+        self::assertFalse(ValidateCnpj::validateCnpj('11.111.111/1111-11', false));
+    }
+
+    public function testAlphanumericRootsIgnoreNumericBlacklist(): void
+    {
+        $root = 'AAAAAAAAAAAA';
+        $raw = self::makeRawCnpj($root);
+        self::assertTrue(ValidateCnpj::validateCnpj($raw));
     }
 }

--- a/tests/UnitValidateCnpjTest.php
+++ b/tests/UnitValidateCnpjTest.php
@@ -12,8 +12,12 @@ final class UnitValidateCnpjTest extends TestCase
     private static function charValue(string $ch): int
     {
         $n = ord($ch);
-        if ($n >= 48 && $n <= 57) return $n - 48;
-        if ($n >= 65 && $n <= 90) return $n - 48;
+        if ($n >= 48 && $n <= 57) {
+            return $n - 48;
+        }
+        if ($n >= 65 && $n <= 90) {
+            return $n - 48;
+        }
         return -1;
     }
 
@@ -21,7 +25,9 @@ final class UnitValidateCnpjTest extends TestCase
     {
         $w1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
         $sum = 0;
-        for ($i = 0; $i < 12; $i++) $sum += self::charValue($root[$i]) * $w1[$i];
+        for ($i = 0; $i < 12; $i++) {
+            $sum += self::charValue($root[$i]) * $w1[$i];
+        }
         $r1 = $sum % 11;
         $dv1 = ($r1 < 2) ? 0 : 11 - $r1;
 

--- a/tests/UnitValidateCpfTest.php
+++ b/tests/UnitValidateCpfTest.php
@@ -7,11 +7,198 @@ namespace DevUtils\Test;
 use DevUtils\ValidateCpf;
 use PHPUnit\Framework\TestCase;
 
-class UnitValidateCpfTest extends TestCase
+final class UnitValidateCpfTest extends TestCase
 {
-    public function testValidate(): void
+    private static function calculateVerificationDigits(string $cpfRoot): array
     {
-        self::assertEquals(true, ValidateCpf::validateCpf('257.877.760-89'));
-        self::assertEquals(false, ValidateCpf::validateCpf('257.877.700-88'));
+        $firstDigitSum = 0;
+        for ($position = 0, $multiplier = 10; $position < 9; $position++, $multiplier--) {
+            $firstDigitSum += intval($cpfRoot[$position]) * $multiplier;
+        }
+        $firstRemainder = $firstDigitSum % 11;
+        $firstVerificationDigit = ($firstRemainder < 2) ? 0 : 11 - $firstRemainder;
+
+        $secondDigitSum = 0;
+        for ($position = 0, $multiplier = 11; $position < 9; $position++, $multiplier--) {
+            $secondDigitSum += intval($cpfRoot[$position]) * $multiplier;
+        }
+        $secondDigitSum += $firstVerificationDigit * 2;
+        $secondRemainder = $secondDigitSum % 11;
+        $secondVerificationDigit = ($secondRemainder < 2) ? 0 : 11 - $secondRemainder;
+
+        return [$firstVerificationDigit, $secondVerificationDigit];
+    }
+
+    private static function generateRawCpf(string $cpfRoot): string
+    {
+        [$firstDigit, $secondDigit] = self::calculateVerificationDigits($cpfRoot);
+        return $cpfRoot . $firstDigit . $secondDigit;
+    }
+
+    private static function formatCpfWithMask(string $rawCpf): string
+    {
+        return sprintf(
+            '%s.%s.%s-%s',
+            substr($rawCpf, 0, 3),
+            substr($rawCpf, 3, 3),
+            substr($rawCpf, 6, 3),
+            substr($rawCpf, 9, 2)
+        );
+    }
+
+    public function testValidNumericExamples(): void
+    {
+        self::assertTrue(ValidateCpf::validateCpf('257.877.760-89'));
+        self::assertFalse(ValidateCpf::validateCpf('257.877.700-88'));
+        self::assertTrue(ValidateCpf::validateCpf('111.444.777-35'));
+        self::assertFalse(ValidateCpf::validateCpf('111.444.777-36'));
+        self::assertTrue(ValidateCpf::validateCpf('11144477735'));
+        self::assertFalse(ValidateCpf::validateCpf('11144477736'));
+    }
+
+    public function testRejectEmptyAndWhitespace(): void
+    {
+        self::assertFalse(ValidateCpf::validateCpf(''));
+        self::assertFalse(ValidateCpf::validateCpf('   '));
+    }
+
+    public function testValidMaskedAndRaw(): void
+    {
+        $cpfRoots = ['123456789', '987654321', '111222333', '456789012'];
+
+        foreach ($cpfRoots as $cpfRoot) {
+            $rawCpf = self::generateRawCpf($cpfRoot);
+            $maskedCpf = self::formatCpfWithMask($rawCpf);
+            self::assertTrue(ValidateCpf::validateCpf($rawCpf));
+            self::assertTrue(ValidateCpf::validateCpf($maskedCpf));
+        }
+    }
+
+    public function testRejectWithWrongDv(): void
+    {
+        $cpfRoot = '123456789';
+        $rawCpf = self::generateRawCpf($cpfRoot);
+        $tamperedFirstDigit = substr($rawCpf, 0, 10) . ((int)$rawCpf[10] ^ 1);
+        self::assertFalse(ValidateCpf::validateCpf($tamperedFirstDigit));
+
+        $tamperedSecondDigit = substr($rawCpf, 0, 9) . ((int)$rawCpf[9] ^ 1) . $rawCpf[10];
+        self::assertFalse(ValidateCpf::validateCpf($tamperedSecondDigit));
+    }
+
+    public function testAcceptMaskedFormat(): void
+    {
+        $cpfRoot = '123456789';
+        $rawCpf = self::generateRawCpf($cpfRoot);
+        $maskedCpf = self::formatCpfWithMask($rawCpf);
+
+        self::assertTrue(ValidateCpf::validateCpf($rawCpf));
+        self::assertTrue(ValidateCpf::validateCpf($maskedCpf));
+
+        $cpfWithSpaces = '  ' . $maskedCpf . '  ';
+        self::assertTrue(ValidateCpf::validateCpf(trim($cpfWithSpaces)));
+    }
+
+    public function testRejectWrongLengthAfterSanitize(): void
+    {
+        self::assertFalse(ValidateCpf::validateCpf('123.456'));
+        self::assertFalse(ValidateCpf::validateCpf('123456789012'));
+        self::assertFalse(ValidateCpf::validateCpf('12345678'));
+    }
+
+    public function testRejectNumericSequences(): void
+    {
+        self::assertFalse(ValidateCpf::validateCpf('000.000.000-00'));
+        self::assertFalse(ValidateCpf::validateCpf('111.111.111-11'));
+        self::assertFalse(ValidateCpf::validateCpf('222.222.222-22'));
+        self::assertFalse(ValidateCpf::validateCpf('333.333.333-33'));
+        self::assertFalse(ValidateCpf::validateCpf('444.444.444-44'));
+        self::assertFalse(ValidateCpf::validateCpf('555.555.555-55'));
+        self::assertFalse(ValidateCpf::validateCpf('666.666.666-66'));
+        self::assertFalse(ValidateCpf::validateCpf('777.777.777-77'));
+        self::assertFalse(ValidateCpf::validateCpf('888.888.888-88'));
+        self::assertFalse(ValidateCpf::validateCpf('999.999.999-99'));
+    }
+
+    public function testRejectSequencesWithoutMask(): void
+    {
+        self::assertFalse(ValidateCpf::validateCpf('00000000000'));
+        self::assertFalse(ValidateCpf::validateCpf('11111111111'));
+        self::assertFalse(ValidateCpf::validateCpf('22222222222'));
+        self::assertFalse(ValidateCpf::validateCpf('33333333333'));
+        self::assertFalse(ValidateCpf::validateCpf('44444444444'));
+        self::assertFalse(ValidateCpf::validateCpf('55555555555'));
+        self::assertFalse(ValidateCpf::validateCpf('66666666666'));
+        self::assertFalse(ValidateCpf::validateCpf('77777777777'));
+        self::assertFalse(ValidateCpf::validateCpf('88888888888'));
+        self::assertFalse(ValidateCpf::validateCpf('99999999999'));
+    }
+
+    public function testValidCpfsWithSpecialCases(): void
+    {
+        $validCpfList = [
+            '12345678909',
+            '11144477735',
+            '25787776089',
+        ];
+
+        foreach ($validCpfList as $cpf) {
+            self::assertTrue(ValidateCpf::validateCpf($cpf), "CPF $cpf deveria ser válido");
+        }
+    }
+
+    public function testHandleLeadingZeros(): void
+    {
+        $cpfRoot = '012345678';
+        $rawCpf = self::generateRawCpf($cpfRoot);
+        $maskedCpf = self::formatCpfWithMask($rawCpf);
+
+        self::assertTrue(ValidateCpf::validateCpf($rawCpf));
+        self::assertTrue(ValidateCpf::validateCpf($maskedCpf));
+    }
+
+    public function testRejectInvalidFormats(): void
+    {
+        self::assertFalse(ValidateCpf::validateCpf('abc.def.ghi-jk'));
+        self::assertFalse(ValidateCpf::validateCpf('###.###.###-##'));
+        self::assertFalse(ValidateCpf::validateCpf('...---'));
+    }
+
+    public function testAcceptStandardFormats(): void
+    {
+        $cpfRoot = '123456789';
+        $rawCpf = self::generateRawCpf($cpfRoot);
+
+        self::assertTrue(ValidateCpf::validateCpf($rawCpf));
+
+        $maskedCpf = self::formatCpfWithMask($rawCpf);
+        self::assertTrue(ValidateCpf::validateCpf($maskedCpf));
+
+        self::assertFalse(ValidateCpf::validateCpf(''));
+    }
+
+    public function testEdgeCases(): void
+    {
+        self::assertFalse(ValidateCpf::validateCpf('0'));
+        self::assertFalse(ValidateCpf::validateCpf('123'));
+        self::assertFalse(ValidateCpf::validateCpf('12345678901234567890'));
+    }
+
+    public function testValidCpfGeneratedByAlgorithm(): void
+    {
+        $testCpfRoots = [
+            '100200300',
+            '200300400',
+            '300400500',
+            '400500600',
+            '500600700',
+        ];
+
+        foreach ($testCpfRoots as $cpfRoot) {
+            $generatedCpf = self::generateRawCpf($cpfRoot);
+            self::assertTrue(ValidateCpf::validateCpf($generatedCpf), "CPF gerado $generatedCpf deveria ser válido");
+
+            $formattedCpf = self::formatCpfWithMask($generatedCpf);
+            self::assertTrue(ValidateCpf::validateCpf($formattedCpf), "CPF mascarado $formattedCpf deveria ser válido");
+        }
     }
 }


### PR DESCRIPTION
Adiciona validação e formatação para CNPJ com raiz alfanumérica e 2 dígitos verificadores numéricos.
Mantém compatibilidade com CNPJ numérico existente.
Inclui novos testes unitários e ajusta testes antigos.
Corrige erros apontados pelo phpstan.